### PR TITLE
Fix database schema loading

### DIFF
--- a/lib/rspec/parallel/rake_task.rb
+++ b/lib/rspec/parallel/rake_task.rb
@@ -17,7 +17,7 @@ namespace :db do
         stdout = $stdout
         begin
           $stdout = File.open(File::NULL, "w")
-          ActiveRecord::Tasks::DatabaseTasks.load_schema_for(configuration)
+          ActiveRecord::Tasks::DatabaseTasks.load_schema(configuration)
         ensure
           $stdout = stdout
         end


### PR DESCRIPTION
In Rails 5 method 'load_schema_for' was removed from ActiveRecord::Tasks::DatabaseTasks