### PR TITLE
Renames load_schema_for to load_schema

### DIFF
--- a/lib/rspec/parallel/rake_task.rb
+++ b/lib/rspec/parallel/rake_task.rb
@@ -17,7 +17,7 @@ namespace :db do
         stdout = $stdout
         begin
           $stdout = File.open(File::NULL, "w")
-          ActiveRecord::Tasks::DatabaseTasks.load_schema_for(configuration)
+          ActiveRecord::Tasks::DatabaseTasks.load_schema(configuration)
         ensure
           $stdout = stdout
         end


### PR DESCRIPTION
To work with newer versions of Rails this renaming was needed.