### PR TITLE
Handle exit code

### DIFF
--- a/bin/parallel-rspec
+++ b/bin/parallel-rspec
@@ -5,4 +5,5 @@ require "parallel-rspec"
 helper_path = ENV.fetch("RSPEC_PARALLEL_HELPER", "spec/parallel_spec_helper.rb")
 Kernel.load(helper_path) if File.readable?(helper_path)
 
-RSpec::Parallel::Runner.new(ARGV).start
+exit_code = RSpec::Parallel::Runner.new(ARGV).start
+Kernel.exit(exit_code)


### PR DESCRIPTION
Fix https://github.com/yuku/parallel-rspec/issues/7

I checked with spec files of two patterns, 1 is for raising in spec, 2 is for failure of test.

(1)

spec/foo_spec.rb

```
raise
```

(2)

spec/bar_spec.rb

```
example do
  it { expect(2).to eq(1) }
end
```
